### PR TITLE
feat: Add Admin Mode with Teacher Authentication

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,138 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  // Auth elements
+  const userIcon = document.getElementById("user-icon");
+  const userDropdown = document.getElementById("user-dropdown");
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const loggedInUser = document.getElementById("logged-in-user");
+  const loginModal = document.getElementById("login-modal");
+  const closeModal = document.getElementById("close-modal");
+  const loginForm = document.getElementById("login-form");
+  const loginError = document.getElementById("login-error");
+  const signupContainer = document.getElementById("signup-container");
+
+  // Auth state
+  let authToken = localStorage.getItem("authToken");
+  let authUsername = localStorage.getItem("authUsername");
+
+  function isLoggedIn() {
+    return !!authToken;
+  }
+
+  function updateAuthUI() {
+    if (isLoggedIn()) {
+      loginBtn.classList.add("hidden");
+      logoutBtn.classList.remove("hidden");
+      loggedInUser.textContent = `👋 ${authUsername}`;
+      loggedInUser.classList.remove("hidden");
+      signupContainer.classList.remove("hidden");
+      userIcon.textContent = "🔓";
+      userIcon.title = authUsername;
+    } else {
+      loginBtn.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+      loggedInUser.classList.add("hidden");
+      signupContainer.classList.add("hidden");
+      userIcon.textContent = "👤";
+      userIcon.title = "Teacher Login";
+    }
+    // Re-fetch to update delete buttons visibility
+    fetchActivities();
+  }
+
+  // Toggle dropdown
+  userIcon.addEventListener("click", () => {
+    userDropdown.classList.toggle("hidden");
+  });
+
+  // Close dropdown when clicking outside
+  document.addEventListener("click", (e) => {
+    if (!e.target.closest("#user-menu")) {
+      userDropdown.classList.add("hidden");
+    }
+  });
+
+  // Show login modal
+  loginBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    userDropdown.classList.add("hidden");
+  });
+
+  // Close login modal
+  closeModal.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginError.classList.add("hidden");
+    loginForm.reset();
+  });
+
+  // Close modal on outside click
+  loginModal.addEventListener("click", (e) => {
+    if (e.target === loginModal) {
+      loginModal.classList.add("hidden");
+      loginError.classList.add("hidden");
+      loginForm.reset();
+    }
+  });
+
+  // Handle login
+  loginForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        authToken = result.token;
+        authUsername = result.username;
+        localStorage.setItem("authToken", authToken);
+        localStorage.setItem("authUsername", authUsername);
+        loginModal.classList.add("hidden");
+        loginForm.reset();
+        loginError.classList.add("hidden");
+        updateAuthUI();
+      } else {
+        loginError.textContent = result.detail || "Login failed";
+        loginError.classList.remove("hidden");
+      }
+    } catch (error) {
+      loginError.textContent = "Connection error. Please try again.";
+      loginError.classList.remove("hidden");
+    }
+  });
+
+  // Handle logout
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+    } catch (e) {
+      // Logout locally even if server call fails
+    }
+    authToken = null;
+    authUsername = null;
+    localStorage.removeItem("authToken");
+    localStorage.removeItem("authUsername");
+    userDropdown.classList.add("hidden");
+    updateAuthUI();
+  });
+
+  // Function to get auth headers
+  function authHeaders() {
+    return authToken ? { Authorization: `Bearer ${authToken}` } : {};
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
@@ -13,6 +145,10 @@ document.addEventListener("DOMContentLoaded", () => {
       // Clear loading message
       activitiesList.innerHTML = "";
 
+      // Clear existing options (keep the default one)
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
+
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
@@ -21,7 +157,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft =
           details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
+        // Create participants HTML — only show delete buttons if logged in
         const participantsHTML =
           details.participants.length > 0
             ? `<div class="participants-section">
@@ -30,7 +166,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isLoggedIn()
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -56,7 +196,7 @@ document.addEventListener("DOMContentLoaded", () => {
         activitySelect.appendChild(option);
       });
 
-      // Add event listeners to delete buttons
+      // Add event listeners to delete buttons (only present when logged in)
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
@@ -80,6 +220,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: authHeaders(),
         }
       );
 
@@ -88,26 +229,37 @@ document.addEventListener("DOMContentLoaded", () => {
       if (response.ok) {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
+        if (response.status === 401) {
+          handleSessionExpired();
+          return;
+        }
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
       }
 
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
     } catch (error) {
       messageDiv.textContent = "Failed to unregister. Please try again.";
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error unregistering:", error);
     }
+  }
+
+  // Handle expired or invalid session
+  function handleSessionExpired() {
+    authToken = null;
+    authUsername = null;
+    localStorage.removeItem("authToken");
+    localStorage.removeItem("authUsername");
+    updateAuthUI();
+    messageDiv.textContent = "Session expired. Please log in again.";
+    messageDiv.className = "error";
+    messageDiv.classList.remove("hidden");
+    setTimeout(() => messageDiv.classList.add("hidden"), 5000);
   }
 
   // Handle form submission
@@ -124,6 +276,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: authHeaders(),
         }
       );
 
@@ -133,20 +286,18 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
+        if (response.status === 401) {
+          handleSessionExpired();
+          return;
+        }
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
       }
 
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
     } catch (error) {
       messageDiv.textContent = "Failed to sign up. Please try again.";
       messageDiv.className = "error";
@@ -156,5 +307,5 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
-  fetchActivities();
+  updateAuthUI();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,7 +10,35 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="user-menu">
+        <button id="user-icon" title="Teacher Login">👤</button>
+        <div id="user-dropdown" class="hidden">
+          <span id="logged-in-user" class="hidden"></span>
+          <button id="login-btn">Login</button>
+          <button id="logout-btn" class="hidden">Logout</button>
+        </div>
+      </div>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <span id="close-modal" class="close-btn">&times;</span>
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="Enter username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="Enter password" />
+          </div>
+          <div id="login-error" class="error hidden"></div>
+          <button type="submit">Login</button>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,10 +22,126 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
 }
 
 header h1 {
   margin-bottom: 10px;
+}
+
+/* User menu in header */
+#user-menu {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+}
+
+#user-icon {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  color: white;
+  font-size: 20px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: background-color 0.2s;
+}
+
+#user-icon:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+#user-dropdown {
+  position: absolute;
+  right: 0;
+  top: 48px;
+  background: white;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  padding: 12px;
+  min-width: 160px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#user-dropdown button {
+  width: 100%;
+  font-size: 14px;
+  padding: 8px 12px;
+}
+
+#logged-in-user {
+  color: #333;
+  font-size: 14px;
+  font-weight: bold;
+  text-align: center;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #eee;
+}
+
+/* Login Modal */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: white;
+  padding: 30px;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 380px;
+  position: relative;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 10px;
+}
+
+.close-btn {
+  position: absolute;
+  top: 10px;
+  right: 16px;
+  font-size: 24px;
+  color: #999;
+  cursor: pointer;
+  background: none;
+  border: none;
+  line-height: 1;
+}
+
+.close-btn:hover {
+  color: #333;
+}
+
+#login-error {
+  margin-bottom: 12px;
+  padding: 8px;
+  border-radius: 4px;
+  font-size: 14px;
 }
 
 main {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,16 @@
+{
+  "teachers": [
+    {
+      "username": "admin",
+      "password": "admin123"
+    },
+    {
+      "username": "teacher1",
+      "password": "pass123"
+    },
+    {
+      "username": "teacher2",
+      "password": "pass456"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements admin mode so that only authenticated teachers can register and unregister students for activities. Students (unauthenticated users) can still view activities and participants.

Closes #5

## Problem

Students were removing each other from activities to free up spots for themselves, causing disruption and unfairness.

## Changes

| File | Description |
|------|-------------|
| `src/teachers.json` | New file storing teacher credentials (username/password) |
| `src/app.py` | Added `/auth/login` and `/auth/logout` endpoints; `signup` and `unregister` now require a valid Bearer token |
| `src/static/index.html` | Added user icon in header, dropdown menu, and login modal |
| `src/static/app.js` | Auth state management via localStorage; signup form and delete buttons hidden when not logged in |
| `src/static/styles.css` | Styles for user menu, dropdown, and login modal |

## How It Works

- **Not logged in:** Users can view activities and participants but cannot register/unregister anyone
- **Logged in (teacher):** Signup form and ❌ delete buttons are visible; API calls include auth token
- **Login flow:** Click 👤 icon → Login → enter credentials → token stored in browser
- **Credentials:** Read from `teachers.json` on the backend

## Testing

- ✅ Unauthenticated signup returns `401 Not authenticated`
- ✅ Login with valid credentials returns a session token
- ✅ Authenticated signup succeeds
- ✅ Bad credentials return `401 Invalid username or password`
- ✅ Logout invalidates the session